### PR TITLE
Fix to build rpm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 
 import sys
 import subprocess
+from io import open
 
 from setuptools import setup, Command
 
@@ -25,7 +26,7 @@ setup(
     author_email='kevin.samuel@yandex.com',
     py_modules=['pyped'],
     license='GPL2',
-    long_description=open('README.md').read(),
+    long_description=open('README.md', encoding='utf-8').read(),
     description="Replace sed/grep/cut/awk by letting you execute Python "
                  "one-liners in your ordinary shell, like perl does.",
     url='http://github.com/ksamuel/Pyped',


### PR DESCRIPTION
Hello,

I have packaged Pyped for Fedora starting release 22.
I had to create this short patch to allow rpmbuild to not fail at build step.
That will be great to add this to the upstream code, so I could remove the patch inside the "rpm".
